### PR TITLE
Add permissions to fix AWS credentials issue

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -12,6 +12,10 @@ env:
   AWS_REGION: us-east-1
   BUILD_TYPE: Release
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build_and_test_native:
     strategy:


### PR DESCRIPTION
This pull request adds write-access to id-token, which is required for configuring AWS credentials.