### PR TITLE
Revise CloudFront cache invalidation process

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -110,5 +110,4 @@ jobs:
       - name: Invalidate CloudFront cache
         run: |
           INVALIDATION_PATHS="index.html octachip.data octachip.js octachip.wasm roms.json fonts/*"
-          aws cloudfront create-invalidation --distribution-id ${{secrets.DISTRIBUTION_ID_1}} --paths $INVALIDATION_PATHS
-          aws cloudfront create-invalidation --distribution-id ${{secrets.DISTRIBUTION_ID_2}} --paths $INVALIDATION_PATHS
+          aws cloudfront create-invalidation --distribution-id ${{secrets.DISTRIBUTION_ID}} --paths $INVALIDATION_PATHS


### PR DESCRIPTION
One of the previous distributions was just redirecting to the www subdomain, so there were no files to invalidate. This distribution is now removed from the GitHub Actions workflow.