### PR TITLE
Add leading slash to invalidation paths

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -109,5 +109,5 @@ jobs:
 
       - name: Invalidate CloudFront cache
         run: |
-          INVALIDATION_PATHS="index.html octachip.data octachip.js octachip.wasm roms.json fonts/*"
+          INVALIDATION_PATHS="/index.html /octachip.data /octachip.js /octachip.wasm /roms.json /fonts/*"
           aws cloudfront create-invalidation --distribution-id ${{secrets.DISTRIBUTION_ID}} --paths $INVALIDATION_PATHS


### PR DESCRIPTION
Invalidation paths MUST begin with leading slash according to AWS documentation